### PR TITLE
Refuse to load engine for statically linked applications

### DIFF
--- a/engine/inc/keysinuse_engine.h
+++ b/engine/inc/keysinuse_engine.h
@@ -11,7 +11,8 @@ static const char *engine_id = "keysinuse";
 static const char *engine_name = "An engine for logging public key identifiers";
 static const char *keysinuse_conf_location = "/etc/keysinuse/keysinuse.cnf";
 static const char *keysinuse_conf_section = "keysinuse_section";
-static CRYPTO_ONCE once = CRYPTO_ONCE_STATIC_INIT;
+static CRYPTO_ONCE log_once = CRYPTO_ONCE_STATIC_INIT;
+static CRYPTO_ONCE config_once = CRYPTO_ONCE_STATIC_INIT;
 
 static const ENGINE_CMD_DEFN supported_cmds[] =
 {

--- a/engine/src/common.c
+++ b/engine/src/common.c
@@ -18,7 +18,7 @@ void set_logging_backoff(long new_backoff)
 // Set logging backoff to something negative to disable logging
 int global_logging_disabled()
 {
-    return logging_backoff <= 0;
+    return logging_backoff < 0;
 }
 
 keysinuse_info *new_keysinuse_info()

--- a/engine/src/common.c
+++ b/engine/src/common.c
@@ -18,7 +18,7 @@ void set_logging_backoff(long new_backoff)
 // Set logging backoff to something negative to disable logging
 int global_logging_disabled()
 {
-    return logging_backoff < 0;
+    return logging_backoff <= 0;
 }
 
 keysinuse_info *new_keysinuse_info()

--- a/engine/src/keysinuse_rsa.c
+++ b/engine/src/keysinuse_rsa.c
@@ -126,7 +126,7 @@ int get_RSA_keysinuse_info(RSA* rsa, keysinuse_info **info)
     }
 
     *info = RSA_get_ex_data(rsa, rsa_keysinuse_info_index);
-    if (info == NULL)
+    if (*info == NULL)
     {
         log_error("Failed to retrieve keysinuse info from key,OPENSSL_%ld",ERR_get_error());
         return 0;
@@ -134,7 +134,6 @@ int get_RSA_keysinuse_info(RSA* rsa, keysinuse_info **info)
 
     return 1;
 }
-
 
 void on_rsa_key_used(RSA *rsa, unsigned int usage)
 {

--- a/scripts/static_link_test.sh
+++ b/scripts/static_link_test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+# Install keysinuse package
+if [ -e /etc/mariner-release ]; then
+    rpm -i $(ls ./pkg/*.rpm)
+else
+    dpkg --force-depends -i $(ls ./pkg/*.deb)
+fi
+
+openssl version
+openssl engine
+
+# Rebuild the tests natively
+/usr/bin/cmake -H./ -B./build
+/usr/bin/cmake --build ./build --target keysinuse_test_common
+/usr/bin/cmake --build ./build --target keysinuse_static_link
+
+printf "\nStarting static link tests\n"
+chmod 0755 ./bin/test/keysinuse_static_link
+OPENSSL_CONF=$(/usr/bin/openssl version -d | awk '{gsub(/"/, "", $2); print $2}')/openssl.cnf ./bin/test/keysinuse_static_link

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,5 +4,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/test)
 
 add_subdirectory (common)
 add_subdirectory (functional)
+add_subdirectory (static_link)
 add_subdirectory (unit)
 add_subdirectory (latency)

--- a/test/static_link/CMakeLists.txt
+++ b/test/static_link/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(static_link_test)
+find_package(OpenSSL REQUIRED)
+find_package(Threads)
+
+include_directories(
+    ${OPENSSL_INCLUDE_DIR}
+    ${CMAKE_SOURCE_DIR}/engine/inc
+    ./inc
+    ../inc
+)
+
+set(OPENSSL_USE_STATIC_LIBS TRUE)
+
+set(CMAKE_CXX_STANDARD 17)
+
+add_executable(keysinuse_static_link main.cpp)
+
+target_link_libraries(keysinuse_static_link
+    ${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}/test/libkeysinuse_test_common.a
+    ${CMAKE_SOURCE_DIR}/../openssl/libcrypto.a
+    ${CMAKE_THREAD_LIBS_INIT}
+    ${CMAKE_DL_LIBS}
+)

--- a/test/static_link/main.cpp
+++ b/test/static_link/main.cpp
@@ -1,0 +1,197 @@
+#include "test.h"
+
+#include "keysinuse_engine.h"
+
+#include <cstring>
+#include <memory>
+#include <dlfcn.h>
+#include <openssl/conf.h>
+#include <openssl/crypto.h>
+#include <openssl/engine.h>
+
+using namespace std;
+
+const char* conf_key_engine_id = "engine_id";
+const char* conf_key_dynamic_path = "dynamic_path";
+const char* conf_key_default_algorithms = "default_algorithms";
+const char* conf_val_default_algorithms_expected = "RSA,EC";
+const char* symname_bind_engine = "bind_engine";
+
+// The KeysInUse engine should never be loaded by a statically
+// linked application. A check exists in engine bind to enforce
+// this. This test verified that under no circumstances will
+// the engine succeed to load for a statically linked application.
+int main(int argc, char **argv)
+{
+    string keysinuse_so_path;
+    RunTest("== Setup ==", [] ()
+    {
+        if (!OPENSSL_init_crypto(OPENSSL_INIT_ENGINE_DYNAMIC |
+                                 OPENSSL_INIT_LOAD_CONFIG, NULL))
+        {
+            TestFailOpenSSLError("OPENSSL_init_crypto failed");
+            TestFinish();
+        }
+
+        return true;
+    });
+
+    // Verify keysinuse engine configured but not loaded
+    // by statically linked application
+    RunTest("== KeysInUse Engine Load by Config ==", [&keysinuse_so_path] ()
+    {
+        string file(CONF_get1_default_config_file());;
+
+        if (file.empty())
+        {
+            TestFail("Failed to get default config location");
+            TestFinish();
+        }
+
+        CONF *conf = NCONF_new(NULL);
+        if (!NCONF_load(conf, file.c_str(), NULL))
+        {
+            TestFailOpenSSLError("Failed to load default config");
+            TestFinish();
+        }
+
+        // engine_id = keysinuse
+        char* conf_value = NCONF_get_string(conf, keysinuse_conf_section, conf_key_engine_id);
+        if (strcmp(engine_id, conf_value) != 0)
+        {
+            TestFail("Failed to get expected %s."
+                    "\n\tExpected: %s"
+                    "\n\tActual: %s",
+                conf_key_engine_id,
+                engine_id,
+                conf_value);
+            TestFinish();
+        }
+
+        // default_algorithms = RSA,EC
+        conf_value = NCONF_get_string(conf, keysinuse_conf_section, conf_key_default_algorithms);
+        if (strcmp(conf_val_default_algorithms_expected, conf_value) != 0)
+        {
+            TestFail("Failed to get expected %s."
+                    "\n\tExpected: %s"
+                    "\n\tActual: %s",
+                conf_key_default_algorithms,
+                conf_val_default_algorithms_expected,
+                conf_value);
+            TestFinish();
+        }
+
+        // dynamic_path exists
+        conf_value = NCONF_get_string(conf, keysinuse_conf_section, conf_key_dynamic_path);
+        if (conf_value == nullptr)
+        {
+            TestFail("Failed to get %s", conf_key_dynamic_path);
+            TestFinish();
+        }
+
+        keysinuse_so_path = conf_value;
+
+        // dynamic_path points to an engine that can be loaded by OpenSSL
+        shared_ptr<void> engine_so(
+            dlopen(conf_value, RTLD_NOW),
+            dlclose);
+        if (engine_so == nullptr)
+        {
+            TestFail("Failed to load library at %s", conf_value);
+            TestFinish();
+        }
+
+        if (dlsym(engine_so.get(), symname_bind_engine) == NULL)
+        {
+            TestFail("Failed to bind function %s from library: %s", symname_bind_engine, dlerror());
+            TestFinish();
+        }
+
+        // Engine is configured, can be loaded by OpenSSL, and
+        // is configured by default. Ensure it is not available
+        // or default for this static application
+
+        // KeysInUse engine is not accessible by ID
+        shared_ptr<ENGINE> e(
+            ENGINE_by_id(engine_id),
+            ENGINE_free);
+
+        if (e != nullptr)
+        {
+            TestFail("KeysInUse engine loaded by ID");
+            TestFinish();
+        }
+
+        // KeysInUse engine is not the default for RSA
+        e.reset(
+            ENGINE_get_default_RSA(),
+            ENGINE_free);
+        if (e != nullptr &&
+            strcmp(engine_id, ENGINE_get_id(e.get())) != 0)
+        {
+            TestFail("KeysInUse engine default for RSA");
+            TestFinish();
+        }
+
+        // KeysInUse engine is not the default for EC
+        e.reset(
+            ENGINE_get_default_EC(),
+            ENGINE_free);
+        if (e != nullptr &&
+            strcmp(engine_id, ENGINE_get_id(e.get())) != 0)
+        {
+            TestFail("KeysInUse engine default for EC");
+            TestFinish();
+        }
+
+        // KeysInUse engine is not the default for EVP_PKEY_RSA
+        e.reset(
+            ENGINE_get_pkey_meth_engine(EVP_PKEY_RSA),
+            ENGINE_free);
+        if (e != nullptr &&
+            strcmp(engine_id, ENGINE_get_id(e.get())) != 0)
+        {
+            TestFail("KeysInUse engine default for EVP_PKEY_RSA");
+            TestFinish();
+        }
+
+        // KeysInUse engine is not the default for EVP_PKEY_RSA_PSS
+        e.reset(
+            ENGINE_get_pkey_meth_engine(EVP_PKEY_RSA_PSS),
+            ENGINE_free);
+        if (e != nullptr &&
+            strcmp(engine_id, ENGINE_get_id(e.get())) != 0)
+        {
+            TestFail("KeysInUse engine default for EVP_PKEY_RSA_PSS");
+            TestFinish();
+        }
+
+        return true;
+    });
+
+    // Verify keysinuse cannot be loaded through dynamic
+    // engine by statically linked applicaiton.
+    RunTest("== KeysInUse Engine Load by Dynamic Engine ==", [keysinuse_so_path] ()
+    {
+        shared_ptr<ENGINE> dynamic (
+            ENGINE_by_id("dynamic"),
+            ENGINE_free);
+
+        if (!ENGINE_ctrl_cmd_string(dynamic.get(), "DIR_LOAD", "2", 0) ||
+            !ENGINE_ctrl_cmd_string(dynamic.get(), "SO_PATH", keysinuse_so_path.c_str(), 0) ||
+            !ENGINE_ctrl_cmd_string(dynamic.get(), "ID", "keysinuse", 0))
+        {
+            TestFailOpenSSLError("Failed to configure dynamic engine for keysinuse load");
+            TestFinish();
+        }
+
+        if (ENGINE_ctrl_cmd_string(dynamic.get(), "LOAD", NULL, 0))
+        {
+            TestFail("KeysInUse engine loaded through dynamic engine");
+            TestFinish();
+        }
+        return true;
+    });
+
+    return 0;
+}

--- a/test/static_link/main.cpp
+++ b/test/static_link/main.cpp
@@ -3,6 +3,7 @@
 #include "keysinuse_engine.h"
 
 #include <cstring>
+#include <string>
 #include <memory>
 #include <dlfcn.h>
 #include <openssl/conf.h>


### PR DESCRIPTION
Added a check at the beginning of engine bind for statically linked callers. If the caller is statically linked, engine bind will fail and a message will be logged. The caller will continue to operate as if the keysinuse engine is not available.

Added a test to ensure the engine cannot be loaded by statically linked applications by config or the dynamic engine. This will be added to the pipeline to ensure any future changes don't regress this behavior.