### PR TITLE
Patch memory leak for dotnet scenario

### DIFF
--- a/engine/src/keysinuse_ec.c
+++ b/engine/src/keysinuse_ec.c
@@ -52,7 +52,6 @@ static void ec_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
     keysinuse_info *info = (keysinuse_info *)ptr;
 
     if (!global_logging_disabled() &&
-        info != NULL &&
         (info->encrypts > 0 || info->decrypts > 0))
     {
         if (info->key_identifier[0] == '\0' &&
@@ -67,11 +66,16 @@ static void ec_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
                    info->decrypts,
                    info->first_use,
                    time(NULL));
+    }
 
+    if (info != NULL)
+    {
         CRYPTO_THREAD_lock_free(info->lock);
         OPENSSL_free(info);
-        EC_KEY_set_ex_data(eckey, ec_keysinuse_info_index, NULL);
     }
+
+    EC_KEY_set_ex_data(eckey, ec_keysinuse_info_index, NULL);
+    ec_keysinuse_info_index = -1;
 }
 
 static void on_ec_key_used(EC_KEY *eckey, unsigned int usage)

--- a/engine/src/keysinuse_ec.c
+++ b/engine/src/keysinuse_ec.c
@@ -51,31 +51,30 @@ static void ec_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
     EC_KEY *eckey = (EC_KEY *)parent;
     keysinuse_info *info = (keysinuse_info *)ptr;
 
-    if (!global_logging_disabled() &&
-        (info->encrypts > 0 || info->decrypts > 0))
-    {
-        if (info->key_identifier[0] == '\0' &&
-            !get_ec_key_identifier(eckey, info))
-        {
-            return;
-        }
-
-        log_notice("%s,%d,%d,%ld,%ld",
-                   info->key_identifier,
-                   info->encrypts,
-                   info->decrypts,
-                   info->first_use,
-                   time(NULL));
-    }
-
     if (info != NULL)
     {
+        if (!global_logging_disabled() &&
+            (info->encrypts > 0 || info->decrypts > 0))
+        {
+            if (info->key_identifier[0] == '\0' &&
+                !get_ec_key_identifier(eckey, info))
+            {
+                return;
+            }
+
+            log_notice("%s,%d,%d,%ld,%ld",
+                    info->key_identifier,
+                    info->encrypts,
+                    info->decrypts,
+                    info->first_use,
+                    time(NULL));
+        }
+
         CRYPTO_THREAD_lock_free(info->lock);
         OPENSSL_free(info);
     }
 
     EC_KEY_set_ex_data(eckey, ec_keysinuse_info_index, NULL);
-    ec_keysinuse_info_index = -1;
 }
 
 static void on_ec_key_used(EC_KEY *eckey, unsigned int usage)

--- a/engine/src/keysinuse_ec.c
+++ b/engine/src/keysinuse_ec.c
@@ -54,14 +54,9 @@ static void ec_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
     if (info != NULL)
     {
         if (!global_logging_disabled() &&
-            (info->encrypts > 0 || info->decrypts > 0))
+            (info->encrypts > 0 || info->decrypts > 0) ||
+            (info->key_identifier[0] != '\0' || get_ec_key_identifier(eckey, info)))
         {
-            if (info->key_identifier[0] == '\0' &&
-                !get_ec_key_identifier(eckey, info))
-            {
-                return;
-            }
-
             log_notice("%s,%d,%d,%ld,%ld",
                     info->key_identifier,
                     info->encrypts,

--- a/engine/src/keysinuse_rsa.c
+++ b/engine/src/keysinuse_rsa.c
@@ -45,32 +45,30 @@ static void rsa_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
     RSA *rsa = (RSA *)parent;
     keysinuse_info *info = (keysinuse_info *)ptr;
 
-    if (!global_logging_disabled() &&
-        info != NULL &&
-        (info->encrypts > 0 || info->decrypts > 0))
-    {
-        if (info->key_identifier[0] == '\0' &&
-            !get_rsa_key_identifier(rsa, info))
-        {
-            return;
-        }
-
-        log_notice("%s,%d,%d,%ld,%ld",
-                   info->key_identifier,
-                   info->encrypts,
-                   info->decrypts,
-                   info->first_use,
-                   time(NULL));
-    }
-
     if (info != NULL)
     {
+        if (!global_logging_disabled() &&
+            (info->encrypts > 0 || info->decrypts > 0))
+        {
+            if (info->key_identifier[0] == '\0' &&
+                !get_rsa_key_identifier(rsa, info))
+            {
+                return;
+            }
+
+            log_notice("%s,%d,%d,%ld,%ld",
+                    info->key_identifier,
+                    info->encrypts,
+                    info->decrypts,
+                    info->first_use,
+                    time(NULL));
+        }
+
         CRYPTO_THREAD_lock_free(info->lock);
         OPENSSL_free(info);
     }
 
     RSA_set_ex_data(rsa, rsa_keysinuse_info_index, NULL);
-    rsa_keysinuse_info_index = -1;
 }
 
 static int get_rsa_key_identifier(RSA *rsa, keysinuse_info *info)

--- a/engine/src/keysinuse_rsa.c
+++ b/engine/src/keysinuse_rsa.c
@@ -61,11 +61,16 @@ static void rsa_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
                    info->decrypts,
                    info->first_use,
                    time(NULL));
+    }
 
+    if (info != NULL)
+    {
         CRYPTO_THREAD_lock_free(info->lock);
         OPENSSL_free(info);
-        RSA_set_ex_data(rsa, rsa_keysinuse_info_index, NULL);
     }
+
+    RSA_set_ex_data(rsa, rsa_keysinuse_info_index, NULL);
+    rsa_keysinuse_info_index = -1;
 }
 
 static int get_rsa_key_identifier(RSA *rsa, keysinuse_info *info)

--- a/engine/src/keysinuse_rsa.c
+++ b/engine/src/keysinuse_rsa.c
@@ -48,14 +48,9 @@ static void rsa_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
     if (info != NULL)
     {
         if (!global_logging_disabled() &&
-            (info->encrypts > 0 || info->decrypts > 0))
+            (info->encrypts > 0 || info->decrypts > 0) &&
+            (info->key_identifier[0] != '\0' || get_rsa_key_identifier(rsa, info)))
         {
-            if (info->key_identifier[0] == '\0' &&
-                !get_rsa_key_identifier(rsa, info))
-            {
-                return;
-            }
-
             log_notice("%s,%d,%d,%ld,%ld",
                     info->key_identifier,
                     info->encrypts,

--- a/engine/src/logging.c
+++ b/engine/src/logging.c
@@ -14,6 +14,7 @@
 #include <openssl/crypto.h>
 
 static const char *default_log_id = "default";
+static const size_t log_id_len_max = 16;
 
 static char *log_id;
 static char *iden;
@@ -27,6 +28,8 @@ static long max_file_size = __LONG_MAX__;
 
 void set_logging_id(char *id)
 {
+    size_t id_len;
+
     // Reset log_id
     if (log_id != NULL &&
         log_id != (char *)default_log_id)
@@ -35,14 +38,20 @@ void set_logging_id(char *id)
     }
     log_id = NULL;
 
+    // Allocate new log_id capped at 16 bytes
     if (id != NULL && *id != '\0')
     {
-        log_id = OPENSSL_malloc(strlen(id) + 1);
+        id_len = strlen(id);
+        id_len = id_len > log_id_len_max ? log_id_len_max : id_len;
+        log_id = OPENSSL_malloc(id_len + 1);
     }
 
     if (log_id != NULL)
     {
-        strcpy(log_id, id);
+        strncpy(log_id, id, id_len);
+        // Ensure log_id is null terminated. If id is longer
+        // than id_len then stdncpy will not null terminate log_id
+        log_id[id_len] = '\0';
     }
     else
     {

--- a/packaging/common/changelog
+++ b/packaging/common/changelog
@@ -1,3 +1,8 @@
+keysinuse (0.3.4) stable; urgency=medium
+  * Fixed memory leak in high reload, client only keys.
+
+ -- Maxwell Moyer-McKee <mamckee@microsoft.com>  Tue, 8 Aug 2022 12:00:00 +0800
+
 keysinuse (0.3.3) stable; urgency=medium
   * KeysInUse engine will no longer load for statically linked applications.
 

--- a/packaging/makeenv
+++ b/packaging/makeenv
@@ -1,2 +1,2 @@
 PACKAGE=keysinuse
-VERSION=0.3.3
+VERSION=0.3.4


### PR DESCRIPTION
This memory leak was discovered in dotnet scenarios where a strictly public key was constantly reloaded without caching. This has likely occurred on a smaller scale but was undetected until now due to the specific nature of the scenario.

1. The process has to load a _public_ key multiple times without caching.
2. The process has to be long running enough that OPENSSL_cleanup is never called.

- Fixed memory leak by ensuring keysinuse info data is always explicitly freed with key object destruction, regardless of state.
- Validated all other allocs have a corresponding free in the same function that is always reached or are properly managed
    - log_id is first freed before being set to anything new. This is static and lives through the process lifetime. Added a max size since this can be set by the user.
    - iden is set once during engine bind. This is static and lives through the process lifetime.