### PR TITLE
Ensure key is not null in free_key callback

### DIFF
--- a/engine/src/keysinuse_ec.c
+++ b/engine/src/keysinuse_ec.c
@@ -54,7 +54,7 @@ static void ec_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
     if (info != NULL)
     {
         if (!global_logging_disabled() &&
-            (info->encrypts > 0 || info->decrypts > 0) ||
+            (info->encrypts > 0 || info->decrypts > 0) &&
             (info->key_identifier[0] != '\0' || get_ec_key_identifier(eckey, info)))
         {
             log_notice("%s,%d,%d,%ld,%ld",
@@ -69,7 +69,10 @@ static void ec_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
         OPENSSL_free(info);
     }
 
-    EC_KEY_set_ex_data(eckey, ec_keysinuse_info_index, NULL);
+    if (eckey != NULL)
+    {
+        EC_KEY_set_ex_data(eckey, ec_keysinuse_info_index, NULL);
+    }
 }
 
 static void on_ec_key_used(EC_KEY *eckey, unsigned int usage)
@@ -141,6 +144,9 @@ static void on_ec_key_used(EC_KEY *eckey, unsigned int usage)
 
 static int get_ec_key_identifier(EC_KEY *eckey, keysinuse_info *info)
 {
+    if (eckey == NULL)
+        return 0;
+
     int ret = 1;
     unsigned char *key_buf = NULL,
                   *key_buf_start = NULL;

--- a/engine/src/keysinuse_rsa.c
+++ b/engine/src/keysinuse_rsa.c
@@ -63,11 +63,17 @@ static void rsa_index_free_key(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
         OPENSSL_free(info);
     }
 
-    RSA_set_ex_data(rsa, rsa_keysinuse_info_index, NULL);
+    if (rsa != NULL)
+    {
+        RSA_set_ex_data(rsa, rsa_keysinuse_info_index, NULL);
+    }
 }
 
 static int get_rsa_key_identifier(RSA *rsa, keysinuse_info *info)
 {
+    if (rsa == NULL)
+        return 0;
+
     int ret = 1;
     unsigned char *key_buf = NULL,
                   *key_buf_start = NULL;


### PR DESCRIPTION
Addresses #10. OpenSSL may call the free key callback with a NULL key. Added null checks to the key wherever it is used in TYPE_index_free_key.